### PR TITLE
Changed MAINTAINER (depreciated) to LABEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.1.10-fpm-alpine
 
-MAINTAINER Ric Harvey <ric@ngd.io>
+LABEL maintainer="Ric Harvey <ric@ngd.io>"
 
 ENV php_conf /usr/local/etc/php-fpm.conf
 ENV fpm_conf /usr/local/etc/php-fpm.d/www.conf


### PR DESCRIPTION
## MAINTAINER (depreciated)
* Per the docker docs - https://docs.docker.com/engine/reference/builder/#maintainer-deprecated

Changed MAINTAINER to LABEL per document.