### PR TITLE
added sync to prevent 'text file busy' on slow filesystems

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -138,7 +138,7 @@ fi
 if [[ "$RUN_SCRIPTS" == "1" ]] ; then
   if [ -d "/var/www/html/scripts/" ]; then
     # make scripts executable incase they aren't
-    chmod -Rf 750 /var/www/html/scripts/*
+    chmod -Rf 750 /var/www/html/scripts/*; sync;
     # run scripts in number order
     for i in `ls /var/www/html/scripts/`; do /var/www/html/scripts/$i ; done
   else


### PR DESCRIPTION
When trying to run a script right after `chmod`, you can sometimes get the error `text file busy`.   We have been getting this more and more.    

Basically what is happening is the file changes haven't taken place yet, so the script can't run.   In docker this happens more with aufs than overlay2 because overlay2 is faster.

A simple fix is to sync all changes to filesystem.  This PR adds this.