### PR TITLE
Corrected keyword for enabling HTTP2 for SSL connections

### DIFF
--- a/conf/nginx-site-ssl.conf
+++ b/conf/nginx-site-ssl.conf
@@ -1,6 +1,6 @@
 server {
 	listen 443 ssl http2;
-        listen [::]:443 ssl https2 ipv6only=on; ## listen for ipv6
+	listen [::]:443 ssl http2 ipv6only=on; ## listen for ipv6
 
 	root /var/www/html;
 	index index.php index.html index.htm;


### PR DESCRIPTION
Config uses an incorrect keyword for enabling HTTP/2 on SSL connections ("https2" instead of "http2").  Current effect is that containers invoking letsencrypt-setup will correctly retrieve a cert & shut down nginx, but nginx will not start again due to an incorrect config.

Fix simply corrects the keyword to http2 (correct usage seems to be "ssl http2").

Ref: http://nginx.org/en/docs/http/ngx_http_v2_module.html