### PR TITLE
Do kill the container gracefully

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -30,6 +30,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+stopsignal=QUIT
 
 [program:nginx]
 command=/usr/sbin/nginx -g "daemon off; error_log /dev/stderr info;"
@@ -42,6 +43,7 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+stopsignal=QUIT
 
 [include]
 files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
PHP-FPM & nginx do recognize the SIGQUIT signal as graceful shutdown, useful in kubernetes context for rolling updates ... etc.