### PR TITLE
Add support for /scripts scripting structure

### DIFF
--- a/docs/config_flags.md
+++ b/docs/config_flags.md
@@ -32,6 +32,7 @@ The following flags are a list of all the currently supported options that can b
 | REAL_IP_HEADER          | set to 1 to enable real ip support in the logs                                                                 |
 | REAL_IP_FROM            | set to your CIDR block for real ip in logs                                                                     |
 | RUN_SCRIPTS             | Set to 1 to execute scripts                                                                                    |
+| RUN_SCRIPTS_FROM_DOCKER | Set to 1 to execute scripts from /script/ folder                                                                                   |
 | PGID                    | Set to GroupId you want to use for nginx (helps permissions when using local volume)                           |
 | PUID                    | Set to UserID you want to use for nginx (helps permissions when using local volume)                            |
 | REMOVE_FILES            | Use REMOVE_FILES=0 to prevent the script from clearing out /var/www/html (useful for working with local files) |

--- a/docs/scripting_templating.md
+++ b/docs/scripting_templating.md
@@ -1,5 +1,5 @@
 ## Scripting
-There is often an occasion where you need to run a script on code to do a transformation once code lands in the container. For this reason we have developed scripting support. By including a scripts folder in your git repository and passing the __RUN_SCRIPTS=1__ flag to your command line the container will execute your scripts. Please see the [repo layout guidelines](https://gitlab.com/ric_harvey/nginx-php-fpm/blob/master/docs/repo_layout.md) for more details on how to organise this.
+There is often an occasion where you need to run a script on code to do a transformation once code lands in the container. For this reason we have developed scripting support. By including a scripts folder in your git repository and passing the __RUN_SCRIPTS=1__ flag to your command line the container will execute your scripts. It's also possible to run scripts from outside cloned repo with __RUN_SCRIPTS_FROM_DOCKER=1__ flag on docker command and mapping a folder to /scripts/ inside container. Please see the [repo layout guidelines](https://gitlab.com/ric_harvey/nginx-php-fpm/blob/master/docs/repo_layout.md) for more details on how to organise this.
 
 ## Using environment variables / templating
 To set the variables pass them in as environment variables on the docker command line.

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -211,6 +211,18 @@ if [[ "$RUN_SCRIPTS" == "1" ]] ; then
   fi
 fi
 
+# Run from docker custom scripts
+if [[ "$RUN_SCRIPTS_FROM_DOCKER" == "1" ]] ; then
+  if [ -d "/scripts/" ]; then
+    # make scripts executable incase they aren't
+    chmod -Rf 750 /scripts/*; sync;
+    # run scripts in number order
+    for i in `ls /scripts/`; do /scripts/$i ; done
+  else
+    echo "Can't find script directory"
+  fi
+fi
+
 if [ -z "$SKIP_COMPOSER" ]; then
     # Try auto install for composer
     if [ -f "/var/www/html/composer.lock" ]; then


### PR DESCRIPTION
Hello!

In complement of GIT_ROOT/scripts scripts support, I've also added /scripts support allowing sysadmin to run script besides GIT repo options.

Can you please merge these changes?