### PR TITLE
Remove default annoying FPM decorators

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -252,6 +252,7 @@ RUN echo "cgi.fix_pathinfo=0" > ${php_vars} &&\
     echo "post_max_size = 100M"  >> ${php_vars} &&\
     echo "variables_order = \"EGPCS\""  >> ${php_vars} && \
     echo "memory_limit = 128M"  >> ${php_vars} && \
+    echo "log_limit = 8192" >> ${php_conf} && \
     sed -i \
         -e "s/;catch_workers_output\s*=\s*yes/catch_workers_output = yes/g" \
         -e "s/pm.max_children = 5/pm.max_children = 4/g" \
@@ -265,6 +266,7 @@ RUN echo "cgi.fix_pathinfo=0" > ${php_vars} &&\
         -e "s/;listen.owner = www-data/listen.owner = nginx/g" \
         -e "s/;listen.group = www-data/listen.group = nginx/g" \
         -e "s/listen = 127.0.0.1:9000/listen = \/var\/run\/php-fpm.sock/g" \
+        -e "s/;decorate_workers_output = no/decorate_workers_output = no/g" \
         -e "s/^;clear_env = no$/clear_env = no/" \
         ${fpm_conf}
 #    ln -s /etc/php7/php.ini /etc/php7/conf.d/php.ini && \


### PR DESCRIPTION
Since PHP 7.3, for some strange reason they decide to decorate the output with `[XX-Xxx-20XX 14:10:02] WARNING: [pool www] child XX said into stdout:` which is not useful and makes annyoing to read the logs.

With this changes now you see your logs as before with only the info you want in the logs.