### PR TITLE
Add SKIP_CHMOD flag

### DIFF
--- a/docs/config_flags.md
+++ b/docs/config_flags.md
@@ -38,4 +38,5 @@ The following flags are a list of all the currently supported options that can b
 | REMOVE_FILES            | Use REMOVE_FILES=0 to prevent the script from clearing out /var/www/html (useful for working with local files) |
 | APPLICATION_ENV         | Set this to development to prevent composer deleting local development dependencies                            |
 | SKIP_CHOWN              | Set to 1 to avoid running chown -Rf on /var/www/html                                                           |
+| SKIP_CHMOD              | Set to 1 to avoid running chmod -Rf 750 on /var/www/html/scripts/*                                             |
 | SKIP_COMPOSER           | Set to 1 to avoid installing composer                                                                          |

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -206,8 +206,10 @@ fi
 # Run custom scripts
 if [[ "$RUN_SCRIPTS" == "1" ]] ; then
   if [ -d "/var/www/html/scripts/" ]; then
-    # make scripts executable incase they aren't
-    chmod -Rf 750 /var/www/html/scripts/*; sync;
+    if [ -z "$SKIP_CHMOD" ]; then
+      # make scripts executable incase they aren't
+      chmod -Rf 750 /var/www/html/scripts/*; sync;
+    fi
     # run scripts in number order
     for i in `ls /var/www/html/scripts/`; do /var/www/html/scripts/$i ; done
   else


### PR DESCRIPTION
Add `SKIP_CHMOD` flag to disable running `chmod -Rf 750 /var/www/html/scripts/*; sync;`. If you mount the script dir as readonly, the chmod fails, and no scripts seems to be executed. Reason for mount as readonly is to limit security risks (i.e. if one container is compromised, they could potentially add scripts that are run on all containers using the same volume).