### PR TITLE
Add flags to override scripts dir and disable chmod

### DIFF
--- a/docs/config_flags.md
+++ b/docs/config_flags.md
@@ -33,9 +33,11 @@ The following flags are a list of all the currently supported options that can b
 | REAL_IP_HEADER          | set to 1 to enable real ip support in the logs                                                                 |
 | REAL_IP_FROM            | set to your CIDR block for real ip in logs                                                                     |
 | RUN_SCRIPTS             | Set to 1 to execute scripts                                                                                    |
+| SCRIPTS_DIR             | Change default scripts dir from `/var/www/html/scripts` to your own setting                                    |
 | PGID                    | Set to GroupId you want to use for nginx (helps permissions when using local volume)                           |
 | PUID                    | Set to UserID you want to use for nginx (helps permissions when using local volume)                            |
 | REMOVE_FILES            | Use REMOVE_FILES=0 to prevent the script from clearing out /var/www/html (useful for working with local files) |
 | APPLICATION_ENV         | Set this to development to prevent composer deleting local development dependencies                            |
 | SKIP_CHOWN              | Set to 1 to avoid running chown -Rf on /var/www/html                                                           |
+| SKIP_CHMOD              | Set to 1 to avoid running chmod -Rf 750 on `SCRIPTS_DIR`                                                       |
 | SKIP_COMPOSER           | Set to 1 to avoid installing composer                                                                          |

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -205,11 +205,14 @@ fi
 
 # Run custom scripts
 if [[ "$RUN_SCRIPTS" == "1" ]] ; then
-  if [ -d "/var/www/html/scripts/" ]; then
-    # make scripts executable incase they aren't
-    chmod -Rf 750 /var/www/html/scripts/*; sync;
+  scripts_dir="${SCRIPTS_DIR:-/var/www/html/scripts}"
+  if [ -d "$scripts_dir" ]; then
+    if [ -z "$SKIP_CHMOD" ]; then
+      # make scripts executable incase they aren't
+      chmod -Rf 750 $scripts_dir; sync;
+    fi
     # run scripts in number order
-    for i in `ls /var/www/html/scripts/`; do /var/www/html/scripts/$i ; done
+    for i in `ls $scripts_dir`; do $scripts_dir/$i ; done
   else
     echo "Can't find script directory"
   fi


### PR DESCRIPTION
Add `SKIP_CHMOD` flag to disable running `chmod -Rf 750 $SCRIPTS_DIR; sync;`.
Add `SCRIPTS_DIR` to override default scripts dir (`/var/www/html/scripts`).