### PR TITLE
Fix JPG and Freetype support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -201,10 +201,11 @@ RUN echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repo
     imap-dev \
     libjpeg-turbo-dev \
     postgresql-dev && \
-    docker-php-ext-install gd && \
     docker-php-ext-configure gd \
+      --enable-gd \
       --with-freetype \
       --with-jpeg && \
+    docker-php-ext-install gd && \
      pip install --upgrade pip && \
     #curl iconv session
     #docker-php-ext-install pdo_mysql pdo_sqlite mysqli mcrypt gd exif intl xsl json soap dom zip opcache && \


### PR DESCRIPTION
As per subject.

 Output of `gd_info()`

*Before*

```
Array
(
    [GD Version] => bundled (2.1.0 compatible)
    [FreeType Support] =>
    [GIF Read Support] => 1
    [GIF Create Support] => 1
    [JPEG Support] =>
    [PNG Support] => 1
    [WBMP Support] => 1
    [XPM Support] =>
    [XBM Support] => 1
    [WebP Support] =>
    [BMP Support] => 1
    [AVIF Support] =>
    [TGA Read Support] => 1
    [JIS-mapped Japanese Font Support] =>
)
```

*After*

```
Array
(
    [GD Version] => bundled (2.1.0 compatible)
    [FreeType Support] => 1
    [FreeType Linkage] => with freetype
    [GIF Read Support] => 1
    [GIF Create Support] => 1
    [JPEG Support] => 1
    [PNG Support] => 1
    [WBMP Support] => 1
    [XPM Support] =>
    [XBM Support] => 1
    [WebP Support] =>
    [BMP Support] => 1
    [AVIF Support] =>
    [TGA Read Support] => 1
    [JIS-mapped Japanese Font Support] =>
)
```

