### PR TITLE
Update alpine mirror URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -161,7 +161,7 @@ RUN GPG_KEYS=573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62 \
   && ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
 
-RUN echo @testing http://nl.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
+RUN echo @testing https://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
     echo /etc/apk/respositories && \
     apk update && apk upgrade &&\
     apk add --no-cache \


### PR DESCRIPTION
http://nl.alpinelinux.org/alpine/edge/testing is not available anymore in the [mirrors list](https://mirrors.alpinelinux.org/) and throws 404

Updated to https://dl-cdn.alpinelinux.org/alpine/edge/testing