### PR TITLE
Correctly chown /var/lib/nginx if custom $PUID set in env

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -198,6 +198,7 @@ if [ ! -z "$PUID" ]; then
   deluser nginx
   addgroup -g ${PGID} nginx
   adduser -D -S -h /var/cache/nginx -s /sbin/nologin -G nginx -u ${PUID} nginx
+  chown -Rf nginx.nginx /var/lib/nginx
 else
   if [ -z "$SKIP_CHOWN" ]; then
     chown -Rf nginx.nginx /var/www/html


### PR DESCRIPTION
This fix #285 